### PR TITLE
Strengthen auth token handling and login accessibility

### DIFF
--- a/src/features/auth/AuthContext.tsx
+++ b/src/features/auth/AuthContext.tsx
@@ -1,4 +1,10 @@
+/* eslint-disable react-refresh/only-export-components */
 import React from "react";
+import {
+  getToken,
+  removeToken as removeStoredToken,
+  setToken as setStoredToken,
+} from "../../lib/token";
 
 type AuthContextValue = {
   token: string | null;
@@ -9,21 +15,21 @@ type AuthContextValue = {
 const AuthContext = React.createContext<AuthContextValue | null>(null);
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
-  const [token, setToken] = React.useState<string | null>(
-    localStorage.getItem("token"),
-  );
+  const [token, setToken] = React.useState<string | null>(getToken());
 
   // Fake login: accept anything, set a pretend token
   async function login(username: string, password: string) {
+    void username;
+    void password;
     // here you'd POST to /login with username/password
     // await api.post('/login', { username, password })
     const fakeToken = "demo-token";
-    localStorage.setItem("token", fakeToken);
+    setStoredToken(fakeToken);
     setToken(fakeToken);
   }
 
   function logout() {
-    localStorage.removeItem("token");
+    removeStoredToken();
     setToken(null);
   }
 

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -1,13 +1,18 @@
 import axios from "axios";
+import { getToken } from "../token";
+const apiUrl = import.meta.env.VITE_API_URL;
+if (!apiUrl) {
+  throw new Error("VITE_API_URL is not defined");
+}
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL,
+  baseURL: apiUrl,
   withCredentials: false,
 });
 
 // Interceptor: before every request, attach token if we have one
 api.interceptors.request.use((config) => {
-  const token = localStorage.getItem("token"); // (fake for now)
+  const token = getToken();
   if (token) {
     config.headers = config.headers ?? {};
     config.headers.Authorization = `Bearer ${token}`;

--- a/src/lib/token.ts
+++ b/src/lib/token.ts
@@ -1,0 +1,32 @@
+export function getToken(): string | null {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return null;
+  }
+  try {
+    return window.localStorage.getItem("token");
+  } catch {
+    return null;
+  }
+}
+
+export function setToken(token: string): void {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.setItem("token", token);
+  } catch {
+    // ignore write errors
+  }
+}
+
+export function removeToken(): void {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.removeItem("token");
+  } catch {
+    // ignore remove errors
+  }
+}

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -1,12 +1,15 @@
 import { useState } from "react";
-import { useLocation, useNavigate } from "react-router-dom";
+import { useLocation, useNavigate, type Location } from "react-router-dom";
 import { useAuth } from "../features/auth/AuthContext";
 
 export default function Login() {
   const { login } = useAuth();
   const navigate = useNavigate();
-  const location = useLocation();
-  const from = (location.state as any)?.from?.pathname || "/projects";
+  interface LocationState {
+    from?: Location;
+  }
+  const location = useLocation<LocationState>();
+  const from = location.state?.from?.pathname || "/projects";
 
   const [username, setUsername] = useState("");
   const [password, setPassword] = useState("");
@@ -20,19 +23,25 @@ export default function Login() {
   return (
     <form onSubmit={onSubmit} className="max-w-sm space-y-4">
       <h2 className="text-lg font-medium">Login</h2>
-      <input
-        className="w-full rounded border border-slate-300 p-2 dark:border-slate-700 dark:bg-slate-800"
-        placeholder="Username"
-        value={username}
-        onChange={(e) => setUsername(e.target.value)}
-      />
-      <input
-        className="w-full rounded border border-slate-300 p-2 dark:border-slate-700 dark:bg-slate-800"
-        placeholder="Password"
-        type="password"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-      />
+      <label className="block">
+        <span className="mb-1 block">Username</span>
+        <input
+          id="username"
+          className="w-full rounded border border-slate-300 p-2 dark:border-slate-700 dark:bg-slate-800"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+        />
+      </label>
+      <label className="block">
+        <span className="mb-1 block">Password</span>
+        <input
+          id="password"
+          className="w-full rounded border border-slate-300 p-2 dark:border-slate-700 dark:bg-slate-800"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </label>
       <button className="rounded bg-sky-600 px-3 py-2 text-white hover:bg-sky-700">
         Sign in
       </button>


### PR DESCRIPTION
## Summary
- type login navigation state and add labels to inputs for accessibility
- add safe token helpers and reuse them in auth context and API client
- validate API base URL at startup before creating Axios instance

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ba6dd80ff8832a8a20a459fb0c57f0